### PR TITLE
Exclude servlet-api dependencies from avalon-framework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,10 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
             


### PR DESCRIPTION
The referenced library version of servlet-api in avalon-framework
is rather old such that it interferes with some tests in the
feature/covide19-digital-green-certificates branch.