### PR TITLE
ERE-411-Webscoket-Fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <quarkus-plugin.version>1.13.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.13.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.13.7.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,6 +10,7 @@
 directory-watcher.dir=${ERE_DIRECTORY_WATCHER_DIR}
 
 quarkus.http.host=0.0.0.0
+quarkus.websocket.max-frame-size=10485760
 
 ## Console Logging ##
 quarkus.log.console.level=INFO


### PR DESCRIPTION
Quarkus version update and websocket limit configuration
- Updated Quarkus version to 1.13.7.Final
- Set websocket max-frame-size to 10MB using the configuration: "quarkus.websocket.max-frame-size".