### PR TITLE
ERE-379-EndpointAutoDiscovery

### DIFF
--- a/src/main/java/health/ere/ps/config/AppConfig.java
+++ b/src/main/java/health/ere/ps/config/AppConfig.java
@@ -1,20 +1,20 @@
 package health.ere.ps.config;
 
+import health.ere.ps.service.connector.endpoint.EndpointDiscoveryService;
 import org.apache.commons.lang3.StringUtils;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-import java.util.Arrays;
-
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 @ApplicationScoped
 public class AppConfig {
-	
-	@ConfigProperty(name = "idp.connector.cert.auth.store.file")
+
+    @ConfigProperty(name = "connector.cert.auth.store.file")
     String idpConnectorTlsCertTrustStore;
 
-    @ConfigProperty(name = "idp.connector.cert.auth.store.file.password")
+    @ConfigProperty(name = "connector.cert.auth.store.file.password")
     String idpConnectorTlsCertTustStorePwd;
 
     @ConfigProperty(name = "idp.client.id")
@@ -32,20 +32,17 @@ public class AppConfig {
     @ConfigProperty(name = "connector.card.handle")
     String cardHandle;
 
-    @ConfigProperty(name = "idp.connector.auth-signature.endpoint.address")
-    String idpConnectorAuthSignatureEndpointAddress;
-
     @ConfigProperty(name = "connector.context.userId")
     String signatureServiceContextUserId;
 
     @ConfigProperty(name = "connector.simulator.titusClientCertificate")
     String titusClientCertificate;
 
-    @ConfigProperty(name = "titus.event-service.endpoint.address")
-    String eventServiceEndpointAddress;
-
     @ConfigProperty(name = "ere.validator.validate.sign.request.bundles.enabled")
     String validateSignRequestBundles;
+
+    @Inject
+    EndpointDiscoveryService endpointDiscoveryService;
 
     public String getIdpConnectorTlsCertTrustStore() {
         return idpConnectorTlsCertTrustStore;
@@ -72,15 +69,11 @@ public class AppConfig {
     }
 
     public String getIdpConnectorAuthSignatureEndpointAddress() {
-        return idpConnectorAuthSignatureEndpointAddress;
+        return endpointDiscoveryService.getAuthSignatureServiceEndpointAddress();
     }
 
     public String getSignatureServiceContextUserId() {
         return signatureServiceContextUserId;
-    }
-
-    public String getEventServiceEndpointAddress() {
-        return eventServiceEndpointAddress;
     }
 
     public String getTitusClientCertificate() {
@@ -98,5 +91,21 @@ public class AppConfig {
     public boolean isValidateSignRequestBundles() {
         return StringUtils.isNotBlank(validateSignRequestBundles) &&
                 validateSignRequestBundles.equalsIgnoreCase("Yes");
+    }
+
+    public String getAuthSignatureServiceEndpointAddress() {
+        return endpointDiscoveryService.getAuthSignatureServiceEndpointAddress();
+    }
+
+    public String getCertificateServiceEndpointAddress() {
+        return endpointDiscoveryService.getCertificateServiceEndpointAddress();
+    }
+
+    public String getSignatureServiceEndpointAddress() {
+        return endpointDiscoveryService.getSignatureServiceEndpointAddress();
+    }
+
+    public String getEventServiceEndpointAddress() {
+        return endpointDiscoveryService.getEventServiceEndpointAddress();
     }
 }

--- a/src/main/java/health/ere/ps/service/connector/certificate/CardCertReadExecutionService.java
+++ b/src/main/java/health/ere/ps/service/connector/certificate/CardCertReadExecutionService.java
@@ -10,6 +10,7 @@ import de.gematik.ws.conn.certificateservicecommon.v2.X509DataInfoListType;
 import de.gematik.ws.conn.connectorcommon.v5.Status;
 import de.gematik.ws.conn.connectorcontext.v2.ContextType;
 
+import health.ere.ps.config.AppConfig;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.io.FileInputStream;
@@ -35,12 +36,12 @@ public class CardCertReadExecutionService {
 
     @Inject
     SecretsManagerService secretsManagerService;
-    
-    @ConfigProperty(name = "idp.connector.certificate-service.endpoint.address")
-    String certificateServiceEndpointAddress;
 
     @ConfigProperty(name = "connector.simulator.titusClientCertificate", defaultValue = "!")
     String titusClientCertificate;
+
+    @Inject
+    AppConfig appConfig;
 
     private CertificateServicePortType certificateService;
 
@@ -56,7 +57,7 @@ public class CardCertReadExecutionService {
         BindingProvider bp = (BindingProvider) certificateService;
         
         bp.getRequestContext().put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY,
-        certificateServiceEndpointAddress);
+        appConfig.getCertificateServiceEndpointAddress());
         
         if (titusClientCertificate != null && !("".equals(titusClientCertificate))
             && !("!".equals(titusClientCertificate))) {

--- a/src/main/java/health/ere/ps/service/connector/endpoint/EndpointDiscoveryService.java
+++ b/src/main/java/health/ere/ps/service/connector/endpoint/EndpointDiscoveryService.java
@@ -1,0 +1,251 @@
+package health.ere.ps.service.connector.endpoint;
+
+import health.ere.ps.exception.common.security.SecretsManagerException;
+import health.ere.ps.service.common.security.SecretsManagerService;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Invocation;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.ws.BindingProvider;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * This service automatically discovers the endpoints that are available at the connector.
+ */
+@ApplicationScoped
+public class EndpointDiscoveryService {
+    private static final Logger LOG = Logger.getLogger(EndpointDiscoveryService.class.getName());
+
+    /**
+     * Certificate to authenticate at the connector.
+     */
+    @ConfigProperty(name = "connector.cert.auth.store.file")
+    Optional<String> connectorTlsCertAuthStoreFile;
+
+    /**
+     * Password of the certificate to authenticate at the connector.
+     * The default value is a empty sting, so that the password must not be set.
+     */
+    @ConfigProperty(name = "connector.cert.auth.store.file.password", defaultValue = "!")
+    String connectorTlsCertAuthStorePwd;
+
+    /**
+     * Certificate to validate with the connector.
+     */
+    @ConfigProperty(name = "connector.cert.trust.store.file")
+    Optional<String> connectorTlsCertTrustStoreFile;
+
+    /**
+     * Password of the certificate to authenticate at the connector.
+     * The default value is a empty sting, so that the password must not be set.
+     */
+    @ConfigProperty(name = "connector.cert.trust.store.file.password", defaultValue = "!")
+    String connectorTlsCertTrustStorePwd;
+
+    @ConfigProperty(name = "auth-signature.endpoint.address")
+    Optional<String> fallbackAuthSignatureServiceEndpointAddress;
+
+    private String authSignatureServiceEndpointAddress;
+
+    @ConfigProperty(name = "signature-service.endpoint.address")
+    Optional<String> fallbackSignatureServiceEndpointAddress;
+
+    private String signatureServiceEndpointAddress;
+
+    @ConfigProperty(name = "certificate-service.endpoint.address")
+    Optional<String> fallbackCertificateServiceEndpointAddress;
+
+    private String certificateServiceEndpointAddress;
+
+    @ConfigProperty(name = "event-service.endpoint.address")
+    Optional<String> fallbackEventServiceEndpointAddress;
+
+    private String eventServiceEndpointAddress;
+
+    @ConfigProperty(name = "connector.base-uri")
+    String connectorBaseUri;
+
+    @ConfigProperty(name = "connector.verify-hostname", defaultValue = "true")
+    String connectorVerifyHostname;
+
+    @Inject
+    SecretsManagerService secretsManagerService;
+
+    @PostConstruct
+    void obtainConfiguration() throws IOException, ParserConfigurationException, SecretsManagerException {
+        // code copied from IdpClient.java
+
+        SSLContext sslContext;
+        try (FileInputStream fileInputStream = new FileInputStream(connectorTlsCertAuthStoreFile.orElseThrow())) {
+            sslContext = secretsManagerService.createSSLContext(fileInputStream,
+                    connectorTlsCertAuthStorePwd.toCharArray(),
+                    SecretsManagerService.SslContextType.TLS,
+                    SecretsManagerService.KeyStoreType.PKCS12);
+        } catch (IOException e) {
+            throw new SecretsManagerException("SSL transport configuration error.", e);
+        }
+
+        ClientBuilder clientBuilder = ClientBuilder.newBuilder()
+                .sslContext(sslContext);
+
+        if (!isConnectorVerifyHostnames()) {
+            // disable hostname verification
+            clientBuilder = clientBuilder.hostnameVerifier(new SSLUtilities.FakeHostnameVerifier());
+        }
+
+        Invocation invocation = clientBuilder.build()
+                .target(connectorBaseUri)
+                .path("/connector.sds")
+                .request()
+                .buildGet();
+
+        try (InputStream inputStream = invocation.invoke(InputStream.class)) {
+            Document document = DocumentBuilderFactory.newDefaultInstance()
+                    .newDocumentBuilder()
+                    .parse(inputStream);
+
+            Node serviceInformationNode = getNodeWithTag(document.getDocumentElement(), "ServiceInformation");
+
+            if (serviceInformationNode == null) {
+                throw new IllegalArgumentException("Could not find single 'ServiceInformation'-tag");
+            }
+
+            NodeList serviceNodeList = serviceInformationNode.getChildNodes();
+
+            for (int i = 0, n = serviceNodeList.getLength(); i < n; ++i) {
+                Node node = serviceNodeList.item(i);
+
+                if (node.getNodeType() != 1) {
+                    // ignore formatting related text nodes
+                    continue;
+                }
+
+                if (!node.hasAttributes() || node.getAttributes().getNamedItem("Name") == null) {
+                    break;
+                }
+
+                switch (node.getAttributes().getNamedItem("Name").getTextContent()) {
+                    case "AuthSignatureService": {
+                        authSignatureServiceEndpointAddress = getEndpoint(node);
+                        break;
+                    }
+                    case "EventService": {
+                        eventServiceEndpointAddress = getEndpoint(node);
+                        break;
+                    }
+                    case "CertificateService": {
+                        certificateServiceEndpointAddress = getEndpoint(node);
+                        break;
+                    }
+                    case "SignatureService": {
+                        signatureServiceEndpointAddress = getEndpoint(node);
+                    }
+                }
+            }
+
+        } catch (SAXException | IllegalArgumentException e) {
+            LOG.log(Level.SEVERE, "Could not parse connector.sds", e);
+        }
+
+        if (authSignatureServiceEndpointAddress == null) {
+            authSignatureServiceEndpointAddress = fallbackAuthSignatureServiceEndpointAddress.orElseThrow();
+        }
+        if (signatureServiceEndpointAddress == null) {
+            signatureServiceEndpointAddress = fallbackSignatureServiceEndpointAddress.orElseThrow();
+        }
+        if (eventServiceEndpointAddress == null) {
+            eventServiceEndpointAddress = fallbackEventServiceEndpointAddress.orElseThrow();
+        }
+        if (certificateServiceEndpointAddress == null) {
+            certificateServiceEndpointAddress = fallbackCertificateServiceEndpointAddress.orElseThrow();
+        }
+    }
+
+    public String getAuthSignatureServiceEndpointAddress() {
+        return authSignatureServiceEndpointAddress;
+    }
+
+    public String getSignatureServiceEndpointAddress() {
+        return signatureServiceEndpointAddress;
+    }
+
+    public String getCertificateServiceEndpointAddress() {
+        return certificateServiceEndpointAddress;
+    }
+
+    public String getEventServiceEndpointAddress() {
+        return eventServiceEndpointAddress;
+    }
+
+    private boolean isConnectorVerifyHostnames() {
+        return !("false".equals(connectorVerifyHostname));
+    }
+
+    public void configureSSLTransportContext(BindingProvider bindingProvider) throws SecretsManagerException, FileNotFoundException {
+
+        secretsManagerService.configureSSLTransportContext(
+                connectorTlsCertAuthStoreFile.orElse(null),
+                connectorTlsCertAuthStorePwd,
+                SecretsManagerService.SslContextType.TLS,
+                SecretsManagerService.KeyStoreType.PKCS12,
+                bindingProvider);
+    }
+
+    private String getEndpoint(Node serviceNode) {
+        Node versionsNode = getNodeWithTag(serviceNode, "Versions");
+
+        if (versionsNode == null) {
+            throw new IllegalArgumentException("No version tags found");
+        }
+
+        NodeList versionNodes = versionsNode.getChildNodes();
+
+        for (int i = 0, n = versionNodes.getLength(); i < n; ++i) {
+            Node endpointNode = getNodeWithTag(versionNodes.item(i), "EndpointTLS");
+
+            if (endpointNode == null || !endpointNode.hasAttributes()
+                    || endpointNode.getAttributes().getNamedItem("Location") == null) {
+                continue;
+            }
+
+            String location = endpointNode.getAttributes().getNamedItem("Location").getTextContent();
+
+            if (location.startsWith(connectorBaseUri)) {
+                return location;
+            }
+        }
+
+        throw new IllegalArgumentException("Invalid service node");
+    }
+
+    private static Node getNodeWithTag(Node node, String tagName) {
+        NodeList nodeList = node.getChildNodes();
+
+        for (int i = 0, n = nodeList.getLength(); i < n; ++i) {
+            Node childNode = nodeList.item(i);
+
+            // ignore namespace entirely
+            if (tagName.equals(childNode.getNodeName()) || childNode.getNodeName().endsWith(":" + tagName)) {
+                return childNode;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/health/ere/ps/service/connector/endpoint/SSLUtilities.java
+++ b/src/main/java/health/ere/ps/service/connector/endpoint/SSLUtilities.java
@@ -1,0 +1,317 @@
+package health.ere.ps.service.connector.endpoint;
+
+/**
+*
+* @author schrepfler
+*/
+
+import javax.net.ssl.*;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+/**
+* This class provide various static methods that relax X509 certificate and
+* hostname verification while using the SSL over the HTTP protocol.
+*
+* @author    Francis Labrie
+*/
+public final class SSLUtilities {
+
+   /**
+    * Hostname verifier for the Sun's deprecated API.
+    *
+    * @deprecated see {@link #_hostnameVerifier}.
+    */
+   private static HostnameVerifier __hostnameVerifier;
+   /**
+    * Thrust managers for the Sun's deprecated API.
+    *
+    * @deprecated see {@link #_trustManagers}.
+    */
+   private static TrustManager[] __trustManagers;
+   /**
+    * Hostname verifier.
+    */
+   private static HostnameVerifier _hostnameVerifier;
+   /**
+    * Thrust managers.
+    */
+   private static TrustManager[] _trustManagers;
+
+   /**
+    * Set the default Hostname Verifier to an instance of a fake class that
+    * trust all hostnames. This method uses the old deprecated API from the
+    * com.sun.ssl package.
+    *
+    * @deprecated see {@link #_trustAllHostnames()}.
+    */
+   private static void __trustAllHostnames() {
+       // Create a trust manager that does not validate certificate chains
+       if (__hostnameVerifier == null) {
+           __hostnameVerifier = new _FakeHostnameVerifier();
+       } // if
+       // Install the all-trusting host name verifier
+       HttpsURLConnection.setDefaultHostnameVerifier(__hostnameVerifier);
+   } // __trustAllHttpsCertificates
+
+   /**
+    * Set the default X509 Trust Manager to an instance of a fake class that
+    * trust all certificates, even the self-signed ones. This method uses the
+    * old deprecated API from the com.sun.ssl package.
+    *
+    * @deprecated see {@link #_trustAllHttpsCertificates()}.
+    */
+   private static void __trustAllHttpsCertificates() {
+       SSLContext context;
+
+       // Create a trust manager that does not validate certificate chains
+       if (__trustManagers == null) {
+           __trustManagers = new TrustManager[]{new _FakeX509TrustManager()};
+       } // if
+       // Install the all-trusting trust manager
+       try {
+           context = SSLContext.getInstance("SSL");
+           context.init(null, __trustManagers, new SecureRandom());
+       } catch (GeneralSecurityException gse) {
+           throw new IllegalStateException(gse.getMessage());
+       } // catch
+       HttpsURLConnection.setDefaultSSLSocketFactory(context.getSocketFactory());
+   } // __trustAllHttpsCertificates
+
+   /**
+    * Return true if the protocol handler property java.
+    * protocol.handler.pkgs is set to the Sun's com.sun.net.ssl.
+    * internal.www.protocol deprecated one, false
+    * otherwise.
+    *
+    * @return                true if the protocol handler
+    * property is set to the Sun's deprecated one, false
+    * otherwise.
+    */
+   private static boolean isDeprecatedSSLProtocol() {
+       return ("com.sun.net.ssl.internal.www.protocol".equals(System.getProperty("java.protocol.handler.pkgs")));
+   } // isDeprecatedSSLProtocol
+
+   /**
+    * Set the default Hostname Verifier to an instance of a fake class that
+    * trust all hostnames.
+    */
+   private static void _trustAllHostnames() {
+       // Create a trust manager that does not validate certificate chains
+       if (_hostnameVerifier == null) {
+           _hostnameVerifier = new FakeHostnameVerifier();
+       } // if
+       // Install the all-trusting host name verifier:
+       HttpsURLConnection.setDefaultHostnameVerifier(_hostnameVerifier);
+   } // _trustAllHttpsCertificates
+
+   /**
+    * Set the default X509 Trust Manager to an instance of a fake class that
+    * trust all certificates, even the self-signed ones.
+    */
+   private static void _trustAllHttpsCertificates() {
+       SSLContext context;
+
+       // Create a trust manager that does not validate certificate chains
+       if (_trustManagers == null) {
+           _trustManagers = new TrustManager[]{new FakeX509TrustManager()};
+       } // if
+       // Install the all-trusting trust manager:
+       try {
+           context = SSLContext.getInstance("SSL");
+           context.init(null, _trustManagers, new SecureRandom());
+       } catch (GeneralSecurityException gse) {
+           throw new IllegalStateException(gse.getMessage());
+       } // catch
+       HttpsURLConnection.setDefaultSSLSocketFactory(context.getSocketFactory());
+   } // _trustAllHttpsCertificates
+
+   /**
+    * Set the default Hostname Verifier to an instance of a fake class that
+    * trust all hostnames.
+    */
+   public static void trustAllHostnames() {
+       // Is the deprecated protocol setted?
+       if (isDeprecatedSSLProtocol()) {
+           __trustAllHostnames();
+       } else {
+           _trustAllHostnames();
+       } // else
+   } // trustAllHostnames
+
+   /**
+    * Set the default X509 Trust Manager to an instance of a fake class that
+    * trust all certificates, even the self-signed ones.
+    */
+   public static void trustAllHttpsCertificates() {
+       // Is the deprecated protocol setted?
+       if (isDeprecatedSSLProtocol()) {
+           __trustAllHttpsCertificates();
+       } else {
+           _trustAllHttpsCertificates();
+       } // else
+   } // trustAllHttpsCertificates
+
+   /**
+    * This class implements a fake hostname verificator, trusting any host
+    * name. This class uses the old deprecated API from the com.sun.
+    * ssl package.
+    *
+    * @author    Francis Labrie
+    *
+    * @deprecated see {@link FakeHostnameVerifier}.
+    */
+   public static class _FakeHostnameVerifier
+           implements HostnameVerifier {
+
+       /**
+        * Always return true, indicating that the host name is an
+        * acceptable match with the server's authentication scheme.
+        *
+        * @param hostname        the host name.
+        * @param session         the SSL session used on the connection to
+        * host.
+        * @return                the true boolean value
+        * indicating the host name is trusted.
+        */
+       public boolean verify(String hostname, SSLSession session) {
+           return (true);
+       }
+   } // _FakeHostnameVerifier
+
+   /**
+    * This class allow any X509 certificates to be used to authenticate the
+    * remote side of a secure socket, including self-signed certificates. This
+    * class uses the old deprecated API from the com.sun.ssl
+    * package.
+    *
+    * @author    Francis Labrie
+    *
+    * @deprecated see {@link FakeX509TrustManager}.
+    */
+   public static class _FakeX509TrustManager
+           implements X509TrustManager {
+
+       /**
+        * Empty array of certificate authority certificates.
+        */
+       private static final X509Certificate[] _AcceptedIssuers =
+               new X509Certificate[]{};
+
+       /**
+        * Always return true, trusting for client SSL
+        * chain peer certificate chain.
+        *
+        * @param chain           the peer certificate chain.
+        * @return                the true boolean value
+        * indicating the chain is trusted.
+        */
+       public boolean isClientTrusted(X509Certificate[] chain) {
+           return (true);
+       } // checkClientTrusted
+
+       /**
+        * Always return true, trusting for server SSL
+        * chain peer certificate chain.
+        *
+        * @param chain           the peer certificate chain.
+        * @return                the true boolean value
+        * indicating the chain is trusted.
+        */
+       public boolean isServerTrusted(X509Certificate[] chain) {
+           return (true);
+       } // checkServerTrusted
+
+       /**
+        * Return an empty array of certificate authority certificates which
+        * are trusted for authenticating peers.
+        *
+        * @return                a empty array of issuer certificates.
+        */
+       public X509Certificate[] getAcceptedIssuers() {
+           return (_AcceptedIssuers);
+       } // getAcceptedIssuers
+
+       public void checkClientTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
+           throw new UnsupportedOperationException("Not supported yet.");
+       }
+
+       public void checkServerTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
+           throw new UnsupportedOperationException("Not supported yet.");
+       }
+   } // _FakeX509TrustManager
+
+   /**
+    * This class implements a fake hostname verificator, trusting any host
+    * name.
+    *
+    * @author    Francis Labrie
+    */
+   public static class FakeHostnameVerifier implements HostnameVerifier {
+
+       /**
+        * Always return true, indicating that the host name is
+        * an acceptable match with the server's authentication scheme.
+        *
+        * @param hostname        the host name.
+        * @param session         the SSL session used on the connection to
+        * host.
+        * @return                the true boolean value
+        * indicating the host name is trusted.
+        */
+       public boolean verify(String hostname,
+               SSLSession session) {
+           return (true);
+       } // verify
+   } // FakeHostnameVerifier
+
+   /**
+    * This class allow any X509 certificates to be used to authenticate the
+    * remote side of a secure socket, including self-signed certificates.
+    *
+    * @author    Francis Labrie
+    */
+   public static class FakeX509TrustManager implements X509TrustManager {
+
+       /**
+        * Empty array of certificate authority certificates.
+        */
+       private static final X509Certificate[] _AcceptedIssuers =
+               new X509Certificate[]{};
+
+       /**
+        * Always trust for client SSL chain peer certificate
+        * chain with any authType authentication types.
+        *
+        * @param chain           the peer certificate chain.
+        * @param authType        the authentication type based on the client
+        * certificate.
+        */
+       public void checkClientTrusted(X509Certificate[] chain,
+               String authType) {
+       } // checkClientTrusted
+
+       /**
+        * Always trust for server SSL chain peer certificate
+        * chain with any authType exchange algorithm types.
+        *
+        * @param chain           the peer certificate chain.
+        * @param authType        the key exchange algorithm used.
+        */
+       public void checkServerTrusted(X509Certificate[] chain,
+               String authType) {
+       } // checkServerTrusted
+
+       /**
+        * Return an empty array of certificate authority certificates which
+        * are trusted for authenticating peers.
+        *
+        * @return                a empty array of issuer certificates.
+        */
+       public X509Certificate[] getAcceptedIssuers() {
+           return (_AcceptedIssuers);
+       } // getAcceptedIssuers
+   } // FakeX509TrustManager
+} // SSLUtilities

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,16 +29,14 @@ quarkus.log.file.rotation.max-file-size=10M
 quarkus.log.file.rotation.max-backup-index=2
 quarkus.log.file.rotation.file-suffix=yyyy-MM-dd
 
-## Titus config ##
-titus.service.base.url=https://kon-instanz2.titus.ti-dienste.de
-titus.prescription.server.url=https://fd.erezept-instanz1.titus.ti-dienste.de
-titus.signature-service.endpointAddress=${titus.service.base.url}:443/soap-api/SignatureService/7.5.4
-titus.event-service.endpoint.address=${titus.service.base.url}/soap-api/EventService/7.2.0
+## Connector Endpoint ##
+connector.base-uri=https://kon-instanz2.titus.ti-dienste.de
 
 ## ERE Workflow Service Config ##
 ere-workflow-service.vau.enable=false
 # User Agent für alle HTTP Requests zum IDP und ERezept-Server Format im Implementierungsleitfaden gemILF_PS_eRp 1.3 vorgegeben. Im Titus-Umfeld 'frei wählbar'
 ere-workflow-service.user-agent=IncentergyGmbH-ere.health/1.0.0
+ere.workflow-service.prescription.server.url=https://fd.erezept-instanz1.titus.ti-dienste.de
 
 ## Connector Config ##
 connector.card.handle=1-2-ARZT-WaltrautDrombusch01
@@ -54,6 +52,8 @@ connector.tvMode=NONE
 # Simulator Config ##
 connector.simulator.titusClientCertificate=${ERE_TITUS_CONNECTOR_TLS_CERT_TRUST_STORE_DIR}/ps_erp_incentergy_01.p12
 connector.simulator.smcbIdentityCertificate=${ERE_TITUS_CONNECTOR_TLS_CERT_TRUST_STORE_DIR}/1-2-ARZT-WaltrautDrombusch01-80276001011699910223-C_SMCB_AUT_R2048_X509.p12
+connector.cert.auth.store.file=${ERE_TITUS_CONNECTOR_TLS_CERT_TRUST_STORE_DIR}/ps_erp_incentergy_01.p12
+connector.cert.auth.store.file.password=${ERE_TITUS_CONNECTOR_TLS_CERT_TRUST_STORE_PWD}
 
 ## Identity Provider Config ##
 idp.base.url=https://idp.erezept-instanz1.titus.ti-dienste.de/auth/realms/idp
@@ -61,7 +61,3 @@ idp.base.url=https://idp.erezept-instanz1.titus.ti-dienste.de/auth/realms/idp
 idp.client.id=gematikTestPs
 idp.auth.request.url=https://idp.erezept-instanz1.titus.ti-dienste.de:443/sign_response
 idp.auth.request.redirect.url=http://test-ps.gematik.de/erezept
-idp.connector.cert.auth.store.file=${ERE_TITUS_CONNECTOR_TLS_CERT_TRUST_STORE_DIR}/ps_erp_incentergy_01.p12
-idp.connector.cert.auth.store.file.password=${ERE_TITUS_CONNECTOR_TLS_CERT_TRUST_STORE_PWD}
-idp.connector.certificate-service.endpoint.address=${titus.service.base.url}/soap-api/CertificateService/6.0.1
-idp.connector.auth-signature.endpoint.address=${titus.service.base.url}/soap-api/AuthSignatureService/7.4.1

--- a/src/test/java/health/ere/ps/service/gematik/ERezeptWorkflowServiceTest.java
+++ b/src/test/java/health/ere/ps/service/gematik/ERezeptWorkflowServiceTest.java
@@ -9,7 +9,6 @@ import health.ere.ps.exception.gematik.ERezeptWorkflowException;
 import health.ere.ps.model.gematik.BundleWithAccessCodeOrThrowable;
 import health.ere.ps.model.muster16.Muster16PrescriptionForm;
 import health.ere.ps.service.extractor.SVGExtractor;
-import health.ere.ps.service.extractor.SVGExtractorConfiguration;
 import health.ere.ps.service.fhir.bundle.PrescriptionBundlesBuilder;
 import health.ere.ps.service.fhir.bundle.PrescriptionBundlesBuilderTest;
 import health.ere.ps.service.muster16.Muster16FormDataExtractorService;
@@ -67,9 +66,9 @@ public class ERezeptWorkflowServiceTest {
         System.setProperty("com.sun.xml.ws.transport.http.HttpAdapter.dumpTreshold", "999999");
 
 //        eRezeptWorkflowService = new ERezeptWorkflowService();
-        eRezeptWorkflowService.prescriptionserverUrl = "https://fd.erezept-instanz1.titus.ti-dienste.de";
-        eRezeptWorkflowService.signatureServiceEndpointAddress = "https://kon-instanz2.titus.ti-dienste.de:443/soap-api/SignatureService/7.5.4";
-        eRezeptWorkflowService.eventServiceEndpointAddress = "https://kon-instanz2.titus.ti-dienste.de/soap-api/EventService/7.2.0";
+        eRezeptWorkflowService.prescriptionServerUrl = "https://fd.erezept-instanz1.titus.ti-dienste.de";
+//        eRezeptWorkflowService.signatureServiceEndpointAddress = "https://kon-instanz2.titus.ti-dienste.de:443/soap-api/SignatureService/7.5.4";
+//        eRezeptWorkflowService.eventServiceEndpointAddress = "https://kon-instanz2.titus.ti-dienste.de/soap-api/EventService/7.2.0";
 //        eRezeptWorkflowService.signatureServiceCardHandle = "1-1-ARZT-WaltrautFinkengrund01";
         eRezeptWorkflowService.signatureServiceContextMandantId = "ps_erp_incentergy_01";
         eRezeptWorkflowService.signatureServiceContextClientSystemId = "ps_erp_incentergy_01_HBA";


### PR DESCRIPTION
Introduced EndpointDiscoveryService.
- Reads service endpoints from the connector directory.
- For configuration centralization, the service is injected only in AppConfig, which exposes the endpoint-values using getters.
- application.properties refactoring