### PR TITLE
NFCKT-1097 when cardlink URLs in the config/konnektoren properties ar…

### DIFF
--- a/src/main/java/health/ere/ps/service/cardlink/CardLinkEndpointConfig.java
+++ b/src/main/java/health/ere/ps/service/cardlink/CardLinkEndpointConfig.java
@@ -1,0 +1,56 @@
+package health.ere.ps.service.cardlink;
+
+import jakarta.websocket.ClientEndpointConfig;
+import jakarta.websocket.Decoder;
+import jakarta.websocket.Encoder;
+import jakarta.websocket.Extension;
+
+import javax.net.ssl.SSLContext;
+import java.util.List;
+import java.util.Map;
+
+public class CardLinkEndpointConfig implements ClientEndpointConfig {
+
+    private final Configurator configurator;
+    private final String serialNumber;
+
+    public CardLinkEndpointConfig(Configurator configurator, String serialNumber) {
+        this.configurator = configurator;
+        this.serialNumber = serialNumber;
+    }
+
+    @Override
+    public List<String> getPreferredSubprotocols() {
+        return List.of(serialNumber);
+    }
+
+    @Override
+    public List<Extension> getExtensions() {
+        return List.of();
+    }
+
+    @Override
+    public SSLContext getSSLContext() {
+        return null;
+    }
+
+    @Override
+    public Configurator getConfigurator() {
+        return configurator;
+    }
+
+    @Override
+    public List<Class<? extends Encoder>> getEncoders() {
+        return List.of();
+    }
+
+    @Override
+    public List<Class<? extends Decoder>> getDecoders() {
+        return List.of();
+    }
+
+    @Override
+    public Map<String, Object> getUserProperties() {
+        return Map.of();
+    }
+}


### PR DESCRIPTION
…e the same for different configs then AddJWTConfigurator Map<String, RuntimeConfig> configMap initalized wrong. On other hand, while CardlinkWebsocketClient connects to the CardLink we should distinguish konnektor configs by something like serial number.