### PR TITLE
Add unit tests for handleUpdateProperties and default handling in UserConfigTest

### DIFF
--- a/src/test/java/health/ere/ps/config/UserConfigTest.java
+++ b/src/test/java/health/ere/ps/config/UserConfigTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import health.ere.ps.event.config.UserConfigurationsUpdateEvent;
 import health.ere.ps.model.config.UserConfigurations;
 import health.ere.ps.service.config.UserConfigurationService;
 
@@ -23,6 +24,9 @@ public class UserConfigTest {
 
         userConfig = new UserConfig();
         userConfig.configurationManagementService = mockConfigService;
+        userConfig.defaultConnectorBaseURI = "https://default.com";
+        userConfig.defaultMandantId = "000000";
+        userConfig.defaultWorkplaceId = "000000";
         userConfig.init();
     }
 
@@ -44,7 +48,25 @@ public class UserConfigTest {
         assertEquals("123456", userConfig.getMandantId());
     }
 
+    @Test
+    public void testGetWorkplaceId_UsesDefault() {
+        assertEquals("000000", userConfig.getWorkplaceId());
+    }
+
     // Add more tests for other configuration properties as needed
+
+    @Test
+    public void testHandleUpdateProperties() {
+        UserConfigurations newConfig = new UserConfigurations();
+        newConfig.setConnectorBaseURL("https://new-url.com");
+        newConfig.setMandantId("999999");
+
+        UserConfigurationsUpdateEvent event = new UserConfigurationsUpdateEvent(newConfig);
+        userConfig.handleUpdateProperties(event);
+
+        assertEquals("https://new-url.com", userConfig.getConnectorBaseURL());
+        assertEquals("999999", userConfig.getMandantId());
+    }
 
     private UserConfigurations createSampleConfig() {
         UserConfigurations config = new UserConfigurations();


### PR DESCRIPTION
This PR adds tests to ensure UserConfig handles configuration updates and defaults correctly.

Changes:

- Add a test for handleUpdateProperties.
- Add a test for default value handling.
- Improve test setup with default values.