### PR TITLE
Add tests for prescription bundle validation

### DIFF
--- a/src/main/java/health/ere/ps/validation/fhir/bundle/PrescriptionBundleValidator.java
+++ b/src/main/java/health/ere/ps/validation/fhir/bundle/PrescriptionBundleValidator.java
@@ -21,6 +21,7 @@ import jakarta.json.JsonArray;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
 
 
@@ -111,6 +112,10 @@ public class PrescriptionBundleValidator {
                     singleBundle.toString());
         JsonObjectBuilder singleBundleResults = Json.createObjectBuilder();
         String bundleJson = singleBundle.toString();
+        // JsonString.toString adds prepending and appending quotation marks.
+        // We have to call JsonString.getString
+        if (singleBundle instanceof JsonString)
+            bundleJson = ((JsonString) singleBundle).getString();
         List<String> errorsList = new ArrayList<>(1);
 
         if (!validateResource(bundleJson,

--- a/src/test/java/health/ere/ps/validation/fhir/bundle/PrescriptionBundleValidatorTest.java
+++ b/src/test/java/health/ere/ps/validation/fhir/bundle/PrescriptionBundleValidatorTest.java
@@ -23,22 +23,29 @@ public class PrescriptionBundleValidatorTest {
 
     FhirContext fhirContext = FhirContext.forR4();
 
+    private String getValidPrescription1() throws IOException {
+        return Files.readString(Paths.get(
+                "src/test" +
+                        "/resources/examples-kbv-fhir-erp-v1-1-0/Beispiel_1.xml"));
+    }
+
+    private String getValidPrescription2() throws IOException {
+        return Files.readString(Paths.get(
+                "src/test" +
+                        "/resources/simplifier_erezept/0428d416-149e-48a4-977c-394887b3d85c.xml"));
+    }
 
     @Test
     public void testKBV() throws IOException {
 
         ValidationResult validationResult =
-                prescriptionBundleValidator.validateResource(Files.readString(Paths.get(
-                "src/test" +
-                "/resources/examples-kbv-fhir-erp-v1-1-0/Beispiel_1.xml")), true);
+                prescriptionBundleValidator.validateResource(getValidPrescription1(), true);
 
         Assertions.assertTrue(validationResult.isValid(), "Sample simplifier.net bundle " +
                 "has been successfully validated.");
 
         validationResult =
-                prescriptionBundleValidator.validateResource(Files.readString(Paths.get(
-                "src/test" +
-                "/resources/simplifier_erezept/0428d416-149e-48a4-977c-394887b3d85c.xml")), true);
+                prescriptionBundleValidator.validateResource(getValidPrescription2(), true);
 
         Assertions.assertTrue(validationResult.isValid(), "Sample simplifier.net bundle " +
                 "has been successfully validated.");


### PR DESCRIPTION
# What changed? 

This pull requests adds a test for prescription bundle validation. 
The test revealed, that Json String aren't validated correctly. Reason is, that jakarta returns different values when you use `toString` and `getString` on a `JsonString` object.

```java
JsonValue tmpValue = Json.createValue("Hello World");
tmpValue.toString();  // ->  ""Hello World""

JsonString tmpString = (JsonString) tmpValue;
tmpString.getString() // -> "Hello World"
```

Reference: https://jakarta.ee/learn/docs/jakartaee-tutorial/current/web/jsonp/jsonp.html#_navigating_an_object_model

# How changed?

We now check for a JsonString. If `singleBundle` is an instance of `JsonString`, we cast it to `JsonString` and proceed with the `getString()` value.
