### PR TITLE
ERE-755 Bugfix: Der Request besitzt keine gültige Signatur

### DIFF
--- a/src/main/java/health/ere/ps/service/connector/auth/SmcbAuthenticatorService.java
+++ b/src/main/java/health/ere/ps/service/connector/auth/SmcbAuthenticatorService.java
@@ -54,9 +54,8 @@ public class SmcbAuthenticatorService {
     @Inject
     AppConfig appConfig;
 
-    private X509Certificate x509Certificate;
 
-    public String signIdpChallenge(Pair<String, String> jwtPair, RuntimeConfig runtimeConfig) {
+    public String signIdpChallenge(Pair<String, String> jwtPair, RuntimeConfig runtimeConfig, X509Certificate certificate) {
         JsonWebSignatureWithExternalAuthentication jws = new JsonWebSignatureWithExternalAuthentication(runtimeConfig);
         jws.setPayload(new String(Base64.getUrlDecoder().decode(jwtPair.getRight())));
 
@@ -70,15 +69,11 @@ public class SmcbAuthenticatorService {
                 .forEach(entry -> jws.setHeader(entry.getKey(),
                         entry.getValue().getAsString()));
         try {
-            jws.setCertificateChainHeaderValue(x509Certificate);
+            jws.setCertificateChainHeaderValue(certificate);
             return jws.getCompactSerialization();
         } catch (JoseException e) {
             throw new IllegalStateException("Error during encryption", e);
         }
-    }
-
-    public void setX509Certificate(X509Certificate x509Certificate) {
-        this.x509Certificate = x509Certificate;
     }
 
     /**

--- a/src/test/java/health/ere/ps/service/idp/client/IdpClientTest.java
+++ b/src/test/java/health/ere/ps/service/idp/client/IdpClientTest.java
@@ -26,6 +26,11 @@ import org.junit.jupiter.api.Test;
 
 import java.security.Security;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.logging.Logger;
 
 @QuarkusTest
@@ -79,26 +84,35 @@ public class IdpClientTest {
     }
 
     @Test
-    public void test_Successful_Idp_Login_With_Connector_Smcb() throws IdpJoseException,
-            IdpClientException, IdpException, ConnectorCardCertificateReadException, ConnectorCardsException {
-
+    public void test_Successful_Idp_Login_With_Connector_Smcb() throws Exception {
         discoveryDocumentUrl = appConfig.getIdpBaseURL() + IdpHttpClientService.DISCOVERY_DOCUMENT_URI;
-
         idpClient.init(appConfig.getIdpClientId(), appConfig.getIdpAuthRequestRedirectURL(), discoveryDocumentUrl, true);
         idpClient.initializeClient();
 
-        String cardHandle = connectorCardsService.getConnectorCardHandle(
-                ConnectorCardsService.CardHandleType.SMC_B);
+        int samples = 5;
+        int cnt = 35;
 
-        X509Certificate x509Certificate = cardCertificateReaderService.retrieveSmcbCardCertificate(cardHandle);
+        ExecutorService executor = Executors.newFixedThreadPool(cnt);
+        for (int k = 0; k < samples; k++) {
+            List<Future<IdpTokenResult>> futures = new ArrayList<>();
+            for (int i = 0; i < cnt; i++) {
+                futures.add(executor.submit(() -> {
+                    String cardHandle = connectorCardsService.getConnectorCardHandle(ConnectorCardsService.CardHandleType.SMC_B);
+                    X509Certificate x509Certificate = cardCertificateReaderService.retrieveSmcbCardCertificate(cardHandle);
 
-        IdpTokenResult idpTokenResult = idpClient.login(x509Certificate);
+                    return idpClient.login(x509Certificate);
+                }));
+            }
+            for (Future<IdpTokenResult> future : futures) {
+                IdpTokenResult idpTokenResult = future.get();
 
-        log.info("Access Token: " + idpTokenResult.getAccessToken().getRawString());
+                log.info("Access Token: " + idpTokenResult.getAccessToken().getRawString());
 
-        Assertions.assertNotNull(idpTokenResult, "Idp Token result present.");
-        Assertions.assertNotNull(idpTokenResult.getAccessToken(), "Access Token present");
-        Assertions.assertNotNull(idpTokenResult.getIdToken(), "Id Token present");
+                Assertions.assertNotNull(idpTokenResult, "Idp Token result present.");
+                Assertions.assertNotNull(idpTokenResult.getAccessToken(), "Access Token present");
+                Assertions.assertNotNull(idpTokenResult.getIdToken(), "Id Token present");
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
* Under high load, Konnektor occasionally produces a corrupted signature (AuthSignatureServicePortType.externalAuthenticate)